### PR TITLE
Type checks in use statements and parameter type hints

### DIFF
--- a/src/ValidatorVisitor.php
+++ b/src/ValidatorVisitor.php
@@ -287,6 +287,10 @@
                 if($this->sandbox->isDefinedClass($class)){
                     $node->type = new Node\Name($this->sandbox->getDefinedClass($class));
                 }
+                if ($this->sandbox->isWhitelistedInterface($class))
+                    $this->sandbox->checkInterface($class);
+                else
+                    $this->sandbox->checkType($class);
                 return $node;
             } else if($node instanceof Node\Expr\New_){
                 if(!$this->sandbox->allow_objects){
@@ -358,6 +362,10 @@
                     } else {
                         $this->sandbox->validationError("Sandboxed code attempted use invalid namespace or alias!", Error::DEFINE_ALIAS_ERROR, $node);
                     }
+                    if ($this->sandbox->isWhitelistedInterface($use->alias))
+                        $this->sandbox->checkInterface($use->alias);
+                    else
+                        $this->sandbox->checkType($use->alias);
                 }
                 return false;
             } else if($node instanceof Node\Expr\ShellExec){

--- a/tests/DefaultConfigTest.php
+++ b/tests/DefaultConfigTest.php
@@ -431,4 +431,24 @@
             $this->sandbox->whitelistMagicConst('DIR');
             $this->assertEquals(str_replace('tests', 'src', __DIR__), $this->sandbox->execute(function(){ return __DIR__; }));
         }
+
+        /**
+         * Test whether sandbox disallows non-whitelisted classes in use statements
+         */
+        public function testDisallowsTypeInUse(){
+            $this->expectException('PHPSandbox\Error');
+            $this->sandbox->allow_aliases = true;
+            $this->sandbox->execute('use TestClass;');
+        }
+
+        /**
+         * Test whether sandbox disallows non-whitelisted classes in parameter type hints
+         */
+        public function testDisallowsTypeInParam(){
+            $this->expectException('PHPSandbox\Error');
+            $this->sandbox->allow_functions = true;
+            $this->sandbox->execute(function() {
+                function testTypeInParam(TestClass $param) {};
+            });
+        }
     }


### PR DESCRIPTION
I've extended the code to check for whitelisted types and interfaces in parameter type hints and use statements. Even though this is not strictly required for practical sandbox constraints; for my use of this library this is very helpful. I'm not sure if this breaks other use cases; if so I can add a switch.