### PR TITLE
Fix magic constants __DIR__ and file __FILE__

### DIFF
--- a/src/PHPSandbox.php
+++ b/src/PHPSandbox.php
@@ -2008,12 +2008,12 @@
          *
          * @return  array           Returns the redefined magic constant
          */
-        public function _get_magic_const($name){
+        public function _get_magic_const($name, $executingFile = null){
             $name = $this->normalizeMagicConst($name);
             if(isset($this->definitions['magic_constants'][$name])){
                 $magic_constant = $this->definitions['magic_constants'][$name];
                 if(is_callable($magic_constant)){
-                    return call_user_func_array($magic_constant, [$this]);
+                    return call_user_func_array($magic_constant, [$this, $executingFile]);
                 }
                 return $magic_constant;
             }
@@ -3047,6 +3047,13 @@
          * @return  $this           Returns the PHPSandbox instance for fluent querying
          */
         public function defineMagicConsts(array $magic_constants = []){
+            $this->defineMagicConst('__DIR__', function (PHPSandbox $sandbox, $executingFile = null) {
+                return dirname($executingFile);
+            });
+            $this->defineMagicConst('__FILE__', function (PHPSandbox $sandbox, $executingFile = null) {
+                return $executingFile;
+            });
+
             foreach($magic_constants as $name => $value){
                 $this->defineMagicConst($name, $value);
             }

--- a/src/ValidatorVisitor.php
+++ b/src/ValidatorVisitor.php
@@ -3,7 +3,7 @@
      * @package PHPSandbox
      */
     namespace PHPSandbox;
-    
+
     use PhpParser\Node,
         \PhpParser\NodeVisitorAbstract;
 
@@ -383,7 +383,7 @@
                     $this->sandbox->validationError("Magic constant failed custom validation!", Error::VALID_MAGIC_CONST_ERROR, $node, $name);
                 }
                 if($this->sandbox->isDefinedMagicConst($name)){
-                    return new Node\Expr\MethodCall(new Node\Expr\StaticCall(new Node\Name\FullyQualified("PHPSandbox\\PHPSandbox"), 'getSandbox', [new Node\Scalar\String_($this->sandbox->name)]), '_get_magic_const', [new Node\Arg(new Node\Scalar\String_($name)), new Node\Arg(new Node\Scalar\String_($this->sandbox->getExecutingFile()))], $node->getAttributes());
+                    return new Node\Expr\MethodCall(new Node\Expr\StaticCall(new Node\Name\FullyQualified("PHPSandbox\\PHPSandbox"), 'getSandbox', [new Node\Scalar\String_($this->sandbox->name)]), '_get_magic_const', [new Node\Arg(new Node\Scalar\String_($name))], $node->getAttributes());
                 }
             } else if($name = $this->isKeyword($node)){
                 if(!$this->sandbox->checkKeyword($name)){

--- a/src/ValidatorVisitor.php
+++ b/src/ValidatorVisitor.php
@@ -383,7 +383,7 @@
                     $this->sandbox->validationError("Magic constant failed custom validation!", Error::VALID_MAGIC_CONST_ERROR, $node, $name);
                 }
                 if($this->sandbox->isDefinedMagicConst($name)){
-                    return new Node\Expr\MethodCall(new Node\Expr\StaticCall(new Node\Name\FullyQualified("PHPSandbox\\PHPSandbox"), 'getSandbox', [new Node\Scalar\String_($this->sandbox->name)]), '_get_magic_const', [new Node\Arg(new Node\Scalar\String_($name))], $node->getAttributes());
+                    return new Node\Expr\MethodCall(new Node\Expr\StaticCall(new Node\Name\FullyQualified("PHPSandbox\\PHPSandbox"), 'getSandbox', [new Node\Scalar\String_($this->sandbox->name)]), '_get_magic_const', [new Node\Arg(new Node\Scalar\String_($name)), new Node\Arg(new Node\Scalar\String_($this->sandbox->getExecutingFile()))], $node->getAttributes());
                 }
             } else if($name = $this->isKeyword($node)){
                 if(!$this->sandbox->checkKeyword($name)){

--- a/tests/CodeSamplesTest.php
+++ b/tests/CodeSamplesTest.php
@@ -24,4 +24,14 @@
             $this->sandbox->allow_includes = true;
             $this->sandbox->execute(file_get_contents($path), false, $path);
         }
+
+        public function testPropertiesWithMagickConstants(){
+            $path = __DIR__ . '/samples/properties_with_magic_constants/index.php';
+            $this->sandbox->validate_magic_constants = false;
+            $this->sandbox->allow_classes = true;
+            $this->sandbox->validate_classes = false;
+            $this->sandbox->allow_includes = true;
+            $this->sandbox->capture_output = true;
+            $this->sandbox->execute(file_get_contents($path), false, $path);
+        }
     }

--- a/tests/CodeSamplesTest.php
+++ b/tests/CodeSamplesTest.php
@@ -1,0 +1,27 @@
+<?php
+    use \PHPSandbox\PHPSandbox;
+
+    error_reporting(E_ALL);
+
+    class CodeSamplesTest extends PHPUnit_Framework_TestCase {
+        /**
+         * @var PHPSandbox
+         */
+        protected $sandbox;
+
+        /**
+         * Sets up the test
+         */
+        public function setUp(){
+            $this->sandbox = new PHPSandbox;
+        }
+
+        public function testMultipleIncludes(){
+            $path = __DIR__ . '/samples/multiple-includes/index.php';
+            $this->sandbox->validate_magic_constants = false;
+            $this->sandbox->allow_classes = true;
+            $this->sandbox->validate_classes = false;
+            $this->sandbox->allow_includes = true;
+            $this->sandbox->execute(file_get_contents($path), false, $path);
+        }
+    }

--- a/tests/samples/multiple-includes/index.php
+++ b/tests/samples/multiple-includes/index.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once __DIR__ . "/vendor/autoload.php";
+
+require_once __DIR__ . "/lib.php";

--- a/tests/samples/multiple-includes/lib.php
+++ b/tests/samples/multiple-includes/lib.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . "/vendor/autoload.php";

--- a/tests/samples/multiple-includes/vendor/autoload.php
+++ b/tests/samples/multiple-includes/vendor/autoload.php
@@ -1,0 +1,4 @@
+<?php
+require_once __DIR__ . '/composer/autoload_real.php';
+
+ComposerAutoloaderInit65f31526175b9fc9733d82d2bb4caba0::test();

--- a/tests/samples/multiple-includes/vendor/composer/autoload_real.php
+++ b/tests/samples/multiple-includes/vendor/composer/autoload_real.php
@@ -1,0 +1,9 @@
+<?php
+
+class ComposerAutoloaderInit65f31526175b9fc9733d82d2bb4caba0
+{
+    public static function test()
+    {
+        return "ok";
+    }
+}

--- a/tests/samples/properties_with_magic_constants/index.php
+++ b/tests/samples/properties_with_magic_constants/index.php
@@ -1,0 +1,6 @@
+<?php
+class TestClass {
+    public static $test = __FILE__;
+}
+
+echo TestClass::$test;


### PR DESCRIPTION
There was an issue when the code contains deep dependencies file1 includes file2 includes file3 etc. When the code uses `__FILE__` or `__DIR__`, these constants must contain the current paths of the current directory or file. A simplest but workable solution is to replace `__FILE__` and `__DIR__` before eval-stage.