### PR TITLE
Fix issues with closures, traits, aliases, and interfaces

### DIFF
--- a/src/PHPSandbox.php
+++ b/src/PHPSandbox.php
@@ -5946,13 +5946,13 @@
         }
 
         /** Check function name against PHPSandbox validation rules. This is an internal PHPSandbox function but requires public access to work.
-         * @param   string      $name      String of the function name to check
+         * @param   string|Closure|SandboxedString      $name      String of the function name to check
          *
-         * @throws  Throwable   Throws exception if validation error occurs
+         * @throws  Throwable                           Throws exception if validation error occurs
          *
-         * @return  bool        Returns true if function is valid, this is also used for testing closures
+         * @return  bool                                Returns true if function is valid, this is also used for testing closures
          */
-        public function checkFunc(string $name) : bool {
+        public function checkFunc($name) : bool {
             if(!$this->validate_functions){
                 return true;
             }

--- a/src/PHPSandbox.php
+++ b/src/PHPSandbox.php
@@ -6612,7 +6612,7 @@
             $output = [];
             foreach($this->definitions['aliases'] as $alias){
                 if(is_array($alias) && isset($alias['original']) && is_string($alias['original']) && $alias['original']){
-                    $output[] = 'use ' . $alias['original'] . ((isset($alias['alias']) && is_string($alias['alias']) && $alias['alias']) ? ' as ' . $alias['alias'] : '') . ';';
+                    $output[] = 'use ' . $alias['original'] . ((isset($alias['alias']) && (is_string($alias['alias']) || $alias['alias'] instanceof Node\Identifier) && $alias['alias']) ? ' as ' . $alias['alias'] : '') . ';';
                 } else {
                     $this->validationError("Sandboxed code attempted to use invalid namespace alias: " . $alias['original'], Error::DEFINE_ALIAS_ERROR, null, $alias['original']);
                 }

--- a/src/SandboxWhitelistVisitor.php
+++ b/src/SandboxWhitelistVisitor.php
@@ -49,7 +49,7 @@
                 $this->sandbox->whitelistClass($node->name->toString());
                 $this->sandbox->whitelistType($node->name->toString());
             } else if($node instanceof Node\Stmt\Interface_
-                && is_string($node->name)
+                && (is_string($node->name) || $node->name instanceof Node\Identifier)
                 && $this->sandbox->allow_interfaces
                 && $this->sandbox->auto_whitelist_interfaces
                 && !$this->sandbox->hasBlacklistedInterfaces()

--- a/src/SandboxWhitelistVisitor.php
+++ b/src/SandboxWhitelistVisitor.php
@@ -56,7 +56,7 @@
             ){
                 $this->sandbox->whitelistInterface($node->name);
             } else if($node instanceof Node\Stmt\Trait_
-                && is_string($node->name)
+                && (is_string($node->name) || $node->name instanceof Node\Identifier)
                 && $this->sandbox->allow_traits
                 && $this->sandbox->auto_whitelist_traits
                 && !$this->sandbox->hasBlacklistedTraits()

--- a/src/WhitelistVisitor.php
+++ b/src/WhitelistVisitor.php
@@ -5,6 +5,7 @@
     namespace PHPSandbox;
 
     use PhpParser\Node,
+        PhpParser\NodeTraverser,
         PhpParser\NodeVisitorAbstract,
         Throwable;
 
@@ -115,7 +116,7 @@
                         $this->sandbox->defineNamespace($name);
                     }
                 }
-                return false;
+                return NodeTraverser::REMOVE_NODE;
             } else if($node instanceof Node\Stmt\Use_){
                 foreach($node->uses as $use){
                     if($use instanceof Node\Stmt\UseUse
@@ -129,7 +130,7 @@
                         }
                     }
                 }
-                return false;
+                return NodeTraverser::REMOVE_NODE;
             }
             return null;
         }

--- a/tests/CodeSamplesTest.php
+++ b/tests/CodeSamplesTest.php
@@ -47,6 +47,15 @@
             $this->assertEquals('ok', $result);
         }
 
+        public function testInterfaces() : void {
+            $path = __DIR__ . '/samples/interfaces/index.php';
+            $this->sandbox->allow_interfaces = true;
+            $this->sandbox->allow_classes = true;
+            $this->sandbox->capture_output = true;
+            $result = $this->sandbox->execute(file_get_contents($path), false, $path);
+            $this->assertEquals('ok', $result);
+        }
+
         public function testClosures() : void {
             $path = __DIR__ . '/samples/closures/index.php';
             $this->sandbox->allow_closures = true;

--- a/tests/CodeSamplesTest.php
+++ b/tests/CodeSamplesTest.php
@@ -37,4 +37,22 @@
             $result = $this->sandbox->execute(file_get_contents($path), false, $path);
             $this->assertEquals($path, $result);
         }
+
+        public function testTraits() : void {
+            $path = __DIR__ . '/samples/traits/index.php';
+            $this->sandbox->allow_traits = true;
+            $this->sandbox->allow_classes = true;
+            $this->sandbox->capture_output = true;
+            $result = $this->sandbox->execute(file_get_contents($path), false, $path);
+            $this->assertEquals('ok', $result);
+        }
+
+        public function testClosures() : void {
+            $path = __DIR__ . '/samples/closures/index.php';
+            $this->sandbox->allow_closures = true;
+            $this->sandbox->allow_functions = true;
+            $this->sandbox->capture_output = true;
+            $result = $this->sandbox->execute(file_get_contents($path), false, $path);
+            $this->assertEquals('ok', $result);
+        }
     }

--- a/tests/CodeSamplesTest.php
+++ b/tests/CodeSamplesTest.php
@@ -64,4 +64,14 @@
             $result = $this->sandbox->execute(file_get_contents($path), false, $path);
             $this->assertEquals('ok', $result);
         }
+
+        public function testAliases() : void {
+            $path = __DIR__ . '/samples/aliases/index.php';
+            $this->sandbox->allow_aliases = true;
+            $this->sandbox->capture_output = true;
+            $this->sandbox->whitelistType('PHPUnit\Framework\Exception');
+            $this->sandbox->whitelistType('Exception');
+            $result = $this->sandbox->execute(file_get_contents($path), false, $path);
+            $this->assertEquals('okok', $result);
+        }
     }

--- a/tests/samples/aliases/index.php
+++ b/tests/samples/aliases/index.php
@@ -1,0 +1,11 @@
+<?php
+
+use PHPUnit\Framework\Exception;
+
+use PHPUnit\Runner\Exception as OtherException;
+
+$exception = new Exception('ok');
+echo $exception->getMessage();
+
+$exception = new OtherException('ok');
+echo $exception->getMessage();

--- a/tests/samples/closures/index.php
+++ b/tests/samples/closures/index.php
@@ -1,0 +1,7 @@
+<?php
+
+$func = function (){
+  echo "ok";
+};
+
+$func();

--- a/tests/samples/interfaces/index.php
+++ b/tests/samples/interfaces/index.php
@@ -1,0 +1,18 @@
+<?php
+
+interface MyInterface {
+
+  function getText();
+
+}
+
+class MyImplementor implements MyInterface {
+
+  function getText(){
+    echo 'ok';
+  }
+
+}
+
+$foo = new MyImplementor();
+echo $foo->getText();

--- a/tests/samples/traits/index.php
+++ b/tests/samples/traits/index.php
@@ -1,0 +1,18 @@
+<?php
+
+trait MyTrait {
+
+  function getText () {
+    return 'ok';
+  }
+
+}
+
+class MyClass {
+
+  use MyTrait;
+
+}
+
+$foo = new MyClass();
+echo $foo->getText();


### PR DESCRIPTION
Just started using this project and found that traits and closures were unusable.

For traits, aliases, and interfaces, I found that the name of the trait was always passed to the visitor as `Node\Identifier`, not `string`, but included both for BC. Maybe a change in PHPParser?

For closures, the `$name instanceof` checks in `checkFunc` could never be reached because of the function's type hint.

Sorry to lump them in one PR but that's how I committed it in my fork. I've added test coverage for both cases as well. Thanks!